### PR TITLE
Allow lax includes to be turned on by default.

### DIFF
--- a/lib/activerecord_lax_includes.rb
+++ b/lib/activerecord_lax_includes.rb
@@ -24,7 +24,12 @@ module ActiveRecordLaxIncludes
     end
 
     def lax_includes_enabled?
-      !!Thread.current[:active_record_lax_includes_enabled]
+      result = Thread.current[:active_record_lax_includes_enabled]
+      if result.nil?
+        result = Rails.configuration.respond_to?(:active_record_lax_includes_enabled) &&
+                    Rails.configuration.active_record_lax_includes_enabled
+      end
+      result
     end
   end
 


### PR DESCRIPTION
Add a `Rails.configuration.active_record_lax_includes_enabled` setting to turn on lax includes by default. Any setting stored in the `active_record_lax_includes_enabled` thread local will take precedence over this global setting.
